### PR TITLE
Update ecmaVersion to be 2019 and a number

### DIFF
--- a/01-eslint-install-run-and-configure-eslint/.eslintrc
+++ b/01-eslint-install-run-and-configure-eslint/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended"],
   "rules": {

--- a/02-lint-javascript-by-configuring-and-running-eslint/.eslintrc
+++ b/02-lint-javascript-by-configuring-and-running-eslint/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended"],
   "rules": {

--- a/03-configure-prettier/.eslintrc
+++ b/03-configure-prettier/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended"],
   "rules": {

--- a/04-use-eslint-config-prettier-to-disable-unnecessary-eslint-stylistic-rules/.eslintrc
+++ b/04-use-eslint-config-prettier-to-disable-unnecessary-eslint-stylistic-rules/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended", "eslint-config-prettier"],
   "rules": {

--- a/05-validate-all-files-are-formatted-when-linting/.eslintrc
+++ b/05-validate-all-files-are-formatted-when-linting/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended", "eslint-config-prettier"],
   "rules": {

--- a/06-install-run-and-configure-flow/.eslintrc
+++ b/06-install-run-and-configure-flow/.eslintrc
@@ -1,7 +1,7 @@
 {
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended", "eslint-config-prettier"],
   "rules": {

--- a/07-run-the-validate-script-in-a-pre-commit-git-hook-with-husky/.eslintrc
+++ b/07-run-the-validate-script-in-a-pre-commit-git-hook-with-husky/.eslintrc
@@ -1,7 +1,7 @@
 {
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended", "eslint-config-prettier"],
   "rules": {

--- a/08-auto-format-all-files-and-validate-relevant-files-in-a-precommit-script-with-lint-staged/.eslintrc
+++ b/08-auto-format-all-files-and-validate-relevant-files-in-a-precommit-script-with-lint-staged/.eslintrc
@@ -1,7 +1,7 @@
 {
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": "2018"
+    "ecmaVersion": 2019
   },
   "extends": ["eslint:recommended", "eslint-config-prettier"],
   "rules": {


### PR DESCRIPTION
This PR updates the `parserOptions.ecmaVersion` value in all `.eslintrc` example files to be a number instead of a string, and to be 2019, matching the version used in the branches as they currently exist.


<img width="787" alt="ecma-version-error-message" src="https://user-images.githubusercontent.com/9663417/70918838-c15c8e00-1fed-11ea-82fa-4a59ca404bb3.png">
