### PR TITLE
Makes lint-stated use npm scripts

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,9 +1,9 @@
 {
   "*.+(js|ts|tsx)": [
-    "eslint"
+    "npm run lint"
   ],
   "*.+(js|json|ts|tsx)": [
-    "prettier --write",
+    "npm run format",
     "git add"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "license": "GPLv3",
   "scripts": {
     "build": "babel src --extensions .js,.ts,.tsx --out-dir dist",
-    "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
+    "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx",
     "check-types": "tsc",
     "prettier": "prettier --ignore-path .gitignore \"**/*.+(js|json|ts|tsx)\"",
     "format": "npm run prettier -- --write",
     "check-format": "npm run prettier -- --list-different",
-    "validate": "npm run check-types && npm run check-format && npm run lint && npm run build"
+    "validate": "npm run check-types && npm run check-format && npm run lint -- . && npm run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",


### PR DESCRIPTION
Hi @kentcdodds ,

I noticed here you're calling eslint and prettier directly instead of capitalizing on the script that were built in package.json.

Does it make sense to use the npm scripts in this case? I'm thinking this might create duplication in case we add flags or customize the scripts.