### PR TITLE
Remove unexpected --write flag from prettier script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src --out-dir dist",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "check-types": "tsc",
-    "prettier": "prettier --ignore-path .gitignore --write \"**/*.+(js|json)\"",
+    "prettier": "prettier --ignore-path .gitignore \"**/*.+(js|json)\"",
     "format": "npm run prettier -- --write",
     "check-format": "npm run prettier -- --list-different",
     "validate": "npm-run-all --parallel check-types check-format lint build"


### PR DESCRIPTION
Hi there!

I was copy-pasting these scripts in one of my own projects for ease of setup when I noticed a sneaky little `--write ` flag that formatted all my files when running `check-format` 😄

Thanks for making all these awesome courses btw!